### PR TITLE
增加获取主震余震的函数

### DIFF
--- a/src/components/EarthMap.vue
+++ b/src/components/EarthMap.vue
@@ -11,6 +11,7 @@
 
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import { BLH2XYZ } from '@/plugins/utils'
+import { getEarthquakeRelations } from '@/plugins/utils'
 import earthquakeJson from '@/assets/earthquake_v1.json'
 
 var THREE = require('three')

--- a/src/components/EarthMap.vue
+++ b/src/components/EarthMap.vue
@@ -11,7 +11,6 @@
 
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import { BLH2XYZ } from '@/plugins/utils'
-import { getEarthquakeRelations } from '@/plugins/utils'
 import earthquakeJson from '@/assets/earthquake_v1.json'
 
 var THREE = require('three')

--- a/src/plugins/utils.js
+++ b/src/plugins/utils.js
@@ -1,4 +1,6 @@
 export { BLH2XYZ }
+export { getEarthquakeRelations }
+import earthquakeJson from '@/assets/earthquake_v2.json'
 
 function BLH2XYZ (lng, lat, radius) {
   const phi = (180 + lng) * (Math.PI / 180)
@@ -8,4 +10,18 @@ function BLH2XYZ (lng, lat, radius) {
     y: radius * Math.cos(theta),
     z: radius * Math.sin(theta) * Math.sin(phi)
   }
+}
+
+function getEarthquakeRelations(clickId) {
+  var showList = [];
+  var currentTag = earthquakeJson[clickId].tag;
+  if (currentTag == ""){
+    return showList;
+  }
+  for(var i = 0; i < earthquakeJson.length; i++){
+      if(earthquakeJson[i].tag == currentTag){
+          showList.push(earthquakeJson[i])
+      }
+  }
+  return showList;
 }


### PR DESCRIPTION
import { getEarthquakeRelations } from '@/plugins/utils'
增加获取主震余震的函数
函数为getEarthquakeRelations(clickId)传入点击的id即可
返回的是JSON对象数组，第一个为主震
如果没有相关地震，则返回空数组