### PR TITLE
增加根据起止日期和起止震级返回地震对象数组的函数

### DIFF
--- a/src/plugins/utils.js
+++ b/src/plugins/utils.js
@@ -1,5 +1,6 @@
 export { BLH2XYZ }
 export { getEarthquakeRelations }
+export { getEarthquakeByDateAndMag }
 import earthquakeJson from '@/assets/earthquake_v2.json'
 
 function BLH2XYZ (lng, lat, radius) {
@@ -24,4 +25,22 @@ function getEarthquakeRelations(clickId) {
       }
   }
   return showList;
+}
+
+function getEarthquakeByDateAndMag(startDate, endDate, minMagnitude, maxMagnitude) {
+  var earthquakes = [];
+  var start = new Date(startDate);
+  var end = new Date(endDate);
+  for(var i = 0; i < earthquakeJson.length; i++){
+    var date = new Date(earthquakeJson[i].date);
+    if(date > end){
+      break;
+    }
+    if(date >= start){
+      if(earthquakeJson[i].magnitude >= minMagnitude && earthquakeJson[i].magnitude <= maxMagnitude){
+        earthquakes.push(earthquakeJson[i])
+      }
+    }
+  }
+  return earthquakes;
 }


### PR DESCRIPTION
增加根据起止日期和起止震级返回地震对象数组的函数getEarthquakeByDateAndMag
传入参数(startDate,endDate,minMagnitude,maxMagnitude)
返回地震对象数组
若没有符合条件的则返回空数组